### PR TITLE
Support multicolumn in original dataframe_factory

### DIFF
--- a/shade_ms/dask_utils.py
+++ b/shade_ms/dask_utils.py
@@ -19,17 +19,15 @@ def start_ends(chunks):
         s = e
 
 
-def _create_dataframe(arrays, start, end):
+def _create_dataframe(arrays, start, end, columns):
     index = None if start is None else np.arange(start, end)
 
-    return pd.DataFrame({'x': arrays[0].ravel(),
-                         'y': arrays[1].ravel()},
+    return pd.DataFrame({k: a.ravel() for k, a in zip(columns, arrays)},
                         index=index)
 
-
-def dataframe_factory(out_ind, x, x_ind, y, y_ind, columns=None):
+def dataframe_factory(out_ind, *arginds, columns=None):
     """
-    Creates a dask Dataframe by broadcasting the ``x`` and ``y`` arrays
+    Creates a dask Dataframe by broadcasting  *arginds
     against each other and then ravelling them.
 
     .. code-block:: python
@@ -43,57 +41,55 @@ def dataframe_factory(out_ind, x, x_ind, y, y_ind, columns=None):
     out_ind : sequence
         Output dimensions.
         e.g. :code:`(row, chan)`
-    x : :class:`dask.array.Array`
-        x data
-    x_ind : sequence
-        x dimensions. e.g. :code:`(row,)`
-    y : :class:`dask.array.Array`
-        y data
-    y_ind : sequence
-        y dimensions. e.g. :code:(row,)`
+    *arginds : Sequence of (:class:`dask.array.Array`, index)
+        document me
     columns : sequence, optional
         Dataframe column names.
         Defaults to :code:`[x, y]`
     """
+    if not len(arginds) % 2 == 0:
+        raise ValueError("Must supply an index for each argument")
+
+    args = arginds[::2]
+    inds = arginds[1::2]
+
     if columns is None:
-        columns = ['x', 'y']
+        columns = ['x', 'y'] + ["c%d" % i for i in range(len(args) - 2)]
     else:
-        if not isinstance(columns, (tuple, list)) and len(columns) != 2:
-            raise ValueError("Columns must be a tuple/list "
-                             "of two column names")
+        if (not isinstance(columns, (tuple, list)) and
+            len(columns) != len(args)):
 
-    if not all(i in out_ind for i in x_ind):
-        raise ValueError("x_ind dimensions not in out_ind")
+            raise ValueError("Columns must be a tuple/list of columns "
+                             "matching the number of arrays")
 
-    if not all(i in out_ind for i in y_ind):
-        raise ValueError("y_ind dimensions not in out_ind")
+    have_nan_chunks = False
 
-    if not len(x_ind) == x.ndim:
-        raise ValueError("len(x_ind) != x.ndim")
+    new_args = []
 
-    if not len(y_ind) == y.ndim:
-        raise ValueError("len(y_ind) != y.ndim")
+    for a, (arg, ind) in enumerate(zip(args, inds)):
+        if not all(i in out_ind for i in ind):
+            raise ValueError("Argument %d dimensions not in out_ind" % a)
 
-    have_nan_chunks = (any(np.isnan(c) for dc in x.chunks for c in dc) or
-                       any(np.isnan(c) for dc in y.chunks for c in dc))
+        if not len(ind) == arg.ndim:
+            raise ValueError("Argument %d len(ind) != arg.ndim" % a)
 
-    # Generate slicing tuples that will expand x and y up to the full
-    # resolution
-    expand_x = tuple(slice(None) if i in x_ind else None for i in out_ind)
-    expand_y = tuple(slice(None) if i in y_ind else None for i in out_ind)
+        have_nan_chunks = (any(np.isnan(c) for dc in arg.chunks for c in dc) or
+                           have_nan_chunks)
 
-    bx = x[expand_x]
-    by = y[expand_y]
+        # Generate slicing tuple that will expand arg up to full resolution
+        expand = tuple(slice(None) if i in ind else None for i in out_ind)
+        new_args.append(arg[expand])
 
     # Create meta data so that blockwise doesn't call
     # np.broadcast_arrays and fall over on the tuple
     # of arrays that it returns
-    dtype = np.result_type(x, y)
+    dtype = np.result_type(*args)
     meta = np.empty((0,) * len(out_ind), dtype=dtype)
 
+    blockargs = (v for pair in ((a, out_ind) for a in new_args) for v in pair)
+
     bcast = da.blockwise(np.broadcast_arrays, out_ind,
-                         bx, out_ind,
-                         by, out_ind,
+                         *blockargs,
                          align_arrays=not have_nan_chunks,
                          meta=meta,
                          dtype=dtype)
@@ -114,7 +110,7 @@ def dataframe_factory(out_ind, x, x_ind, y, y_ind, columns=None):
         divisions = [None]
 
         for i, key in enumerate(keys):
-            layers[(name, i)] = (_create_dataframe, key, None, None)
+            layers[(name, i)] = (_create_dataframe, key, None, None, columns)
             divisions.append(None)
     else:
         # We do know all our chunk sizes, create reasonable dataframe indices
@@ -127,7 +123,7 @@ def dataframe_factory(out_ind, x, x_ind, y, y_ind, columns=None):
         chunk_ranges = start_ends(chunk_sizes)
 
         for i, (key, (start, end)) in enumerate(zip(keys, chunk_ranges)):
-            layers[(name, i)] = (_create_dataframe, key, start, end)
+            layers[(name, i)] = (_create_dataframe, key, start, end, columns)
             start_idx += end - start
             divisions.append(start_idx)
 
@@ -137,8 +133,9 @@ def dataframe_factory(out_ind, x, x_ind, y, y_ind, columns=None):
     # Create the HighLevelGraph
     graph = HighLevelGraph.from_collections(name, layers, [bcast])
     # Metadata representing the broadcasted and ravelled data
-    meta = pd.DataFrame(data={'x': np.empty((0,), dtype=x.dtype),
-                              'y': np.empty((0,), dtype=y.dtype)},
+
+    meta = pd.DataFrame(data={k: np.empty((0,), dtype=a.dtype)
+                              for k, a in zip(columns, args)},
                         columns=columns)
 
     # Create the actual Dataframe

--- a/shade_ms/tests/test_dask_utils.py
+++ b/shade_ms/tests/test_dask_utils.py
@@ -53,3 +53,30 @@ def test_dataframe_factory(test_nan_shapes):
     # Compare our lazy dataframe series vs (dask or numpy) arrays
     assert_array_equal(df['x'], x)
     assert_array_equal(df['y'], y)
+
+
+def test_dataframe_factory_multicol():
+    nrow, nfreq, ncorr = 100, 100, 4
+
+    data1a = da.arange(nrow, chunks=(10,))
+    data1b = da.zeros(dtype=float, shape=(nfreq, ncorr), chunks=(100, 4))
+    data1c = da.ones(dtype=np.int32, shape=(ncorr,), chunks=(4,))
+
+    df = dataframe_factory(("row", "chan", "corr"),
+                           data1a, ("row",),
+                           data1b, ("chan", "corr"),
+                           data1c, ("corr",))
+
+    assert isinstance(df, dd.DataFrame)
+    assert isinstance(df['x'], dd.Series)
+    assert isinstance(df['y'], dd.Series)
+    assert isinstance(df['c0'], dd.Series)
+
+
+    x, y, c0 = da.broadcast_arrays(data1a[:, None, None],
+                                   data1b[None, :, :],
+                                   data1c[None, None, :])
+
+    assert_array_equal(df['x'], x.ravel())
+    assert_array_equal(df['y'], y.ravel())
+    assert_array_equal(df['c0'], c0.ravel())


### PR DESCRIPTION
@o-smirnov I think this does what you want, although differently from the approach you were taking. I've gone with ``*arginds`` which implies an argument list of ``arg1, index1, arg2, index2, ... argn, indexn`` in the semantics of [dask.array.blockwise](https://docs.dask.org/en/latest/array-api.html#dask.array.core.blockwise).

Apologies if I've taken away a learning experience but I thought it better to move the code back towards an established blockwise pattern.