### PR TITLE
Use dask arrays in dask ufuncs to avoid nan chunking behaviour

### DIFF
--- a/shade_ms/data_mappers.py
+++ b/shade_ms/data_mappers.py
@@ -312,17 +312,7 @@ class DataAxis(object):
             raise NameError("column {} not found in group".format(" or ".join(self.columns)))
 
     def get_value(self, group, corr, extras, flag, flag_row, chanslice):
-        # if isinstance(flag, xarray.DataArray):
-        #     flag = flag.data
-
-        # if isinstance(flag_row, xarray.DataArray):
-        #     flag_row = flag_row.data
-
         coldata = self.get_column_data(group)
-
-        # if isinstance(coldata, xarray.DataArray):
-        #     coldata = coldata.data
-
         # correlation may be pre-set by plot type, or may be passed to us
         corr = self.corr if self.corr is not None else corr
         # apply correlation reduction
@@ -388,6 +378,7 @@ class DataAxis(object):
                 raise TypeError(f"{self.label}: column chnaged from discrete to continuous-valued. This is a bug, or a very weird MS.")
             self._is_discrete = False
 
+        # Ensure dask arrays for creating dask masked arrays
         if isinstance(coldata, xarray.DataArray):
             coldata = coldata.data
 

--- a/shade_ms/data_mappers.py
+++ b/shade_ms/data_mappers.py
@@ -312,7 +312,17 @@ class DataAxis(object):
             raise NameError("column {} not found in group".format(" or ".join(self.columns)))
 
     def get_value(self, group, corr, extras, flag, flag_row, chanslice):
+        # if isinstance(flag, xarray.DataArray):
+        #     flag = flag.data
+
+        # if isinstance(flag_row, xarray.DataArray):
+        #     flag_row = flag_row.data
+
         coldata = self.get_column_data(group)
+
+        # if isinstance(coldata, xarray.DataArray):
+        #     coldata = coldata.data
+
         # correlation may be pre-set by plot type, or may be passed to us
         corr = self.corr if self.corr is not None else corr
         # apply correlation reduction
@@ -372,11 +382,17 @@ class DataAxis(object):
                 if flag is None:
                     flag = bad_bins
                 else:
-                    flag = da.logical_or(flag, bad_bins)
+                    flag = da.logical_or(flag.data, bad_bins)
         else:
             if self._is_discrete is True:
                 raise TypeError(f"{self.label}: column chnaged from discrete to continuous-valued. This is a bug, or a very weird MS.")
             self._is_discrete = False
+
+        if isinstance(coldata, xarray.DataArray):
+            coldata = coldata.data
+
+        if isinstance(flag, xarray.DataArray):
+            flag = flag.data
 
         bad_data = da.logical_not(da.isfinite(coldata))
         if flag is not None:

--- a/shade_ms/data_plots.py
+++ b/shade_ms/data_plots.py
@@ -446,7 +446,7 @@ def create_plot(ddf, index_subsets, xdatum, ydatum, adatum, ared, cdatum, cmap, 
         alpha -= min_alpha
         if nulls.all():
             log.debug(f"alpha<min_alpha for entire plot -- all data below lower clip perhaps?")
-        else:    
+        else:
             #if percentile if specified, use that to override saturate_alpha
             if saturate_alpha is None:
                 saturate_alpha = np.percentile(alpha[~nulls], saturate_percentile)


### PR DESCRIPTION
Dask ufuncs seem to produce nan chunks when given xarray DataArrays even when this shouldn't strictly happen. Use dask arrays in dask ufuncs to circumvent this.